### PR TITLE
Correction to security group warning

### DIFF
--- a/sdk/python/pulumi_aws/ec2/instance.py
+++ b/sdk/python/pulumi_aws/ec2/instance.py
@@ -193,8 +193,8 @@ class Instance(pulumi.CustomResource):
             __props__['root_block_device'] = root_block_device
             __props__['secondary_private_ips'] = secondary_private_ips
             if security_groups is not None and not opts.urn:
-                warnings.warn("""Use of `securityGroups` is discouraged as it does not allow for changes and will force your instance to be replaced if changes are made. To avoid this, use `vpcSecurityGroupIds` which allows for updates.""", DeprecationWarning)
-                pulumi.log.warn("""security_groups is deprecated: Use of `securityGroups` is discouraged as it does not allow for changes and will force your instance to be replaced if changes are made. To avoid this, use `vpcSecurityGroupIds` which allows for updates.""")
+                warnings.warn("""Use of `security_groups` is discouraged as it does not allow for changes and will force your instance to be replaced if changes are made. To avoid this, use `vpc_security_group_ids` which allows for updates.""", DeprecationWarning)
+                pulumi.log.warn("""security_groups is deprecated: Use of `security_groups` is discouraged as it does not allow for changes and will force your instance to be replaced if changes are made. To avoid this, use `vpc_security_group_ids` which allows for updates.""")
             __props__['security_groups'] = security_groups
             __props__['source_dest_check'] = source_dest_check
             __props__['subnet_id'] = subnet_id


### PR DESCRIPTION
The warning message thrown when using the python sdk instance resource property `security_group`, recommended arguments that neither worked nor matched with the documentation.